### PR TITLE
Mi 101/update login page

### DIFF
--- a/src/frontend/assets/transitions.scss
+++ b/src/frontend/assets/transitions.scss
@@ -1,0 +1,10 @@
+.fade-enter-active, .fade-leave-active {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 250ms ease-out, transform 500ms ease-out;
+}
+
+.fade-enter, .fade-leave-to {
+  opacity: 0;
+  transform: translateY(50px);
+}

--- a/src/frontend/pages/LoginPage.vue
+++ b/src/frontend/pages/LoginPage.vue
@@ -8,7 +8,7 @@
       <transition name="fade" mode="out-in">
       <form v-if="!loginFailed" id="login-form" @submit="handleLogin">
         <input-text class="input-text-wrapper" iconType="mail" type="email" placeholder="E-Mail" v-model="email"/>
-        <input-text class="input-text-wrapper" iconType="key" type="password" hint="Deine Daten stimmen nicht überein, bitte überprüfe noch mal deine Eingabe!" :showHint="wrongLoginData" placeholder="Password" v-model="password"/>
+        <input-text class="input-text-wrapper" iconType="key" type="password" hint="Deine Anmeldedaten stimmen nicht, bitte überprüfe noch mal deine Eingabe!" :showHint="wrongLoginData" placeholder="Password" v-model="password"/>
         <button-submit class="login-button" type="submit" text="Login" to="" :disabled="!password || !email"/>
         <p class="registration-text">Du hast noch keinen Account?</p>
         <router-link class="registration-link" to="/register">Registrieren</router-link>
@@ -84,6 +84,7 @@
 <style scoped lang="scss">
   @import "../assets/variables";
   @import "../assets/mixins";
+  @import "../assets/transitions";
 
   article {
     flex: 1;
@@ -201,17 +202,5 @@
         }
       }
     }
-  }
-
-  //vue transitions
-  .fade-enter-active, .fade-leave-active {
-    opacity: 1;
-    transform: translateY(0);
-    transition: opacity 250ms ease-out, transform 500ms ease-out;
-  }
-
-  .fade-enter, .fade-leave-to {
-    opacity: 0;
-    transform: translateY(50px);
   }
 </style>

--- a/src/frontend/pages/RegistrationPage.vue
+++ b/src/frontend/pages/RegistrationPage.vue
@@ -102,6 +102,7 @@
 <style scoped lang="scss">
   @import "../assets/variables";
   @import "../assets/mixins";
+  @import "../assets/transitions";
 
   article {
     flex: 1;
@@ -219,17 +220,5 @@
         }
       }
     }
-  }
-
-  //vue transitions
-  .fade-enter-active, .fade-leave-active {
-    opacity: 1;
-    transform: translateY(0);
-    transition: opacity 250ms ease-out, transform 500ms ease-out;
-  }
-
-  .fade-enter, .fade-leave-to {
-    opacity: 0;
-    transform: translateY(50px);
   }
 </style>

--- a/src/frontend/pages/RegistrationPage.vue
+++ b/src/frontend/pages/RegistrationPage.vue
@@ -3,25 +3,25 @@
     <header>
       <h1>Meeting</h1>
     </header>
-      <section class="card">
-        <h2>Registrierung</h2>
-        <transition name="fade" mode="out-in">
-          <form v-if="!resultMessage" id="registration-form" @submit="handleRegistration">
-            <input-text class="input-text-wrapper" iconType="person" placeholder="Benutzername" hint="Benutzername muss mind. 4 Zeichen haben" :showHint="username != '' && !usernameValid" v-model="username"/>
-            <input-text class="input-text-wrapper" iconType="mail" placeholder="E-Mail" :hint="emailAlreadyExsists ? 'Es existiert bereits ein Nutzer mit dieser E-Mail-Adresse' : 'E-Mail-Adresse ist unvollständig'" :showHint="emailAlreadyExsists || (email != '' && !emailValid)" v-model="email"/>
-            <input-text class="input-text-wrapper" iconType="key" type="password" placeholder="Passwort" hint="Passwort muss mind. 8 Zeichen haben" :showHint="password != '' && !passwordValid" v-model="password"/>
-            <button-submit class="register-button" type="submit" text="Registrieren" :disabled="!usernameValid || !emailValid || !passwordValid"/>
-            <p class="login-text">Du hast schon einen Account?</p>
-            <router-link class="login-link" to="/login">Anmelden</router-link>
-          </form>
-          <div id="result-wrapper" v-else>
-            <h3>{{resultTitle}}</h3>
-            <p>{{resultMessage}}</p>
-            <icon class="result-icon" :iconType="resultButton === 'Anmelden' ? 'check-circle' : 'error-circle'" iconColor="colorPrimary"/>
-            <button-submit class="result-link" @click="backToForm" to="/login" :type="resultButton === 'Anmelden' ? 'link' : 'button'" :text="resultButton"/>
-          </div>
-        </transition>
-      </section>
+    <section class="card">
+      <h2>Registrierung</h2>
+      <transition name="fade" mode="out-in">
+        <form v-if="!resultMessage" id="registration-form" @submit="handleRegistration">
+          <input-text class="input-text-wrapper" iconType="person" placeholder="Benutzername" hint="Benutzername muss mind. 4 Zeichen haben" :showHint="username != '' && !usernameValid" v-model="username"/>
+          <input-text class="input-text-wrapper" iconType="mail" placeholder="E-Mail" :hint="emailAlreadyExsists ? 'Es existiert bereits ein Nutzer mit dieser E-Mail-Adresse' : 'E-Mail-Adresse ist unvollständig'" :showHint="emailAlreadyExsists || (email != '' && !emailValid)" v-model="email"/>
+          <input-text class="input-text-wrapper" iconType="key" type="password" placeholder="Passwort" hint="Passwort muss mind. 8 Zeichen haben" :showHint="password != '' && !passwordValid" v-model="password"/>
+          <button-submit class="register-button" type="submit" text="Registrieren" :disabled="!usernameValid || !emailValid || !passwordValid"/>
+          <p class="login-text">Du hast schon einen Account?</p>
+          <router-link class="login-link" to="/login">Anmelden</router-link>
+        </form>
+        <div id="result-wrapper" v-else>
+          <h3>{{resultTitle}}</h3>
+          <p>{{resultMessage}}</p>
+          <icon class="result-icon" :iconType="resultButton === 'Anmelden' ? 'check-circle' : 'error-circle'" iconColor="colorPrimary"/>
+          <button-submit class="result-link" @click="backToForm" to="/login" :type="resultButton === 'Anmelden' ? 'link' : 'button'" :text="resultButton"/>
+        </div>
+      </transition>
+    </section>
   </article>
 </template>
 


### PR DESCRIPTION
- added `assets/transitions.scss` for systematic usage of transitions
- reformatted login page to behave like registration page

- page will show error if backend had problems
- page will show hint saying that entered data is wrong if backend returns 401

Vielleicht sollten wir darüber nachdenken, eine Art Hauptseite für das Anmelden+Registrieren einzurichten, die dann mit einer `router-view` zwischen `/login` und `/register` wechselt. Dadurch können wir folgendes tun:
- Übernahme von E-Mail bei Wechsel von Login-Form zu Registration-Form (UX)
- Ruckfreier Wechsel von Login <-> Registration durch Transitions
- Einfacherer Übergang von Login zur Karten-Overview
